### PR TITLE
Add missing link

### DIFF
--- a/src/pyscaffoldext/markdown/templates/index.template
+++ b/src/pyscaffoldext/markdown/templates/index.template
@@ -35,3 +35,4 @@ ${description}
 [Markdown]: https://daringfireball.net/projects/markdown/
 [reStructuredText]: http://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html
 [recommonmark]: https://recommonmark.readthedocs.io/en/latest
+[autostructify]: https://recommonmark.readthedocs.io/en/latest/auto_structify.html


### PR DESCRIPTION
There was the link for `[autostructify]` missing.