### PR TITLE
Replace pyscaffold with variable in contributing template

### DIFF
--- a/src/pyscaffoldext/markdown/templates/contributing.template
+++ b/src/pyscaffoldext/markdown/templates/contributing.template
@@ -243,7 +243,7 @@ conda activate ${name}
 
    ```{todo} if you are using GitHub, you can uncomment the following paragraph
 
-      Find more detailed information `creating a PR`_. You might also want to open
+      Find more detailed information in [creating a PR]. You might also want to open
       the PR as a draft first and mark it as ready for review after the feedbacks
       from the continuous integration (CI) system or any required fixes.
 


### PR DESCRIPTION
Users will probably like to call the conda environment by the name of the package...