### PR TITLE
Fix typecheck errors

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -49,57 +49,54 @@ env:
       - cat .pre-commit-config.yaml
 
 
+# Deep clone script for POSIX environments (required for setuptools-scm)
+.clone_script: &clone |
+  if [ -z "$CIRRUS_PR" ]; then
+    git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
+  else
+    git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+    git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+    git reset --hard $CIRRUS_CHANGE_IN_REPO
+  fi
+
+
 # ---- Task definitions ----
 
 typecheck_task:
   name: typecheck (Linux - 3.9)
+  clone_script: *clone
   container: {image: "python:3.9-buster"}  # most recent => better type support
   pip_cache: *pip-cache
   mypy_cache:
     folder: .mypy_cache
-  install_script: &debian-install
-    - apt-get install -y git
-  mypy_install_script:
-    - python -m pip install --upgrade pip setuptools mypy -e .
+  tox_install_script:
+    - python -m pip install --upgrade pip setuptools tox
+  prepare_script: *prepare
   clean_workspace_script:
     - rm -rf junit-*.xml
   typecheck_script:
-    - python -m mypy src/pyscaffoldext --junit-xml junit-type.xml
-    # ^  apparently mypy does not know how to handle PEP420
+    - python -m tox -e typecheck -- src --junit-xml junit-type.xml
   always: *upload-junit
 
 
 linux_mac_task:
   # Use custom cloning since otherwise git tags are missing
-  clone_script: &clone |
-    if [ -z "$CIRRUS_PR" ]; then
-      git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-      git reset --hard $CIRRUS_CHANGE_IN_REPO
-    else
-      git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
-      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
-      git reset --hard $CIRRUS_CHANGE_IN_REPO
-    fi
+  clone_script: *clone
   matrix:
     - name: test (Linux - 3.6)
       container: {image: "python:3.6-buster"}
-      install_script: *debian-install
     - name: test (Linux - 3.7)
       container: {image: "python:3.7-buster"}
-      install_script: *debian-install
     - name: test (Linux - 3.8)
       container: {image: "python:3.8-buster"}
-      install_script: *debian-install
     - name: test (Linux - 3.9)
       container: {image: "python:3.9-buster"}
-      install_script: *debian-install
     - name: test (Linux - 3.10)
-      allow_failures: true  # Python version is not stable
-      container: {image: "python:3.10-rc-buster"}
-      install_script: *debian-install
+      allow_failures: true  # Some packages (e.g. Sphinx) might still have some problems
+      container: {image: "python:3.10-buster"}
     - name: test (Linux - Anaconda)
       container: {image: "continuumio/anaconda3:2021.05"}
-      install_script: *debian-install
       env:
         USING_CONDA: true
       extra_install_script:
@@ -115,7 +112,7 @@ linux_mac_task:
       brew_cache:
         folder: "$HOME/Library/Caches/Homebrew"
       install_script:
-        - brew install python gnu-tar
+        - brew install python
         - brew cleanup
   <<: *REGULAR_TASK_TEMPLATE
 
@@ -174,7 +171,7 @@ windows_task:
     # Set Windows encoding to UTF-8
     - REG ADD "HKEY_CURRENT_USER\Software\Microsoft\Command Processor" /v Autorun /t REG_SZ /d "@chcp 65001>nul" /f
     - python -m ensurepip
-    - python -m pip install --upgrade --user pip setuptools certifi tox
+    - python -m pip install --upgrade --user pip setuptools certifi tox pre-commit
   prepare_script: *prepare
   clean_workspace_script:
     # Avoid information carried from one run to the other
@@ -197,7 +194,6 @@ coverage_task:
     - test (Linux - 3.8)
     - test (Linux - Anaconda)
     - test (OS X)
-  install_script: *debian-install
   pip_install_script:
     pip install --user --upgrade coverage coveralls pre-commit
   precommit_script:

--- a/src/pyscaffoldext/markdown/extension.py
+++ b/src/pyscaffoldext/markdown/extension.py
@@ -3,7 +3,7 @@ from functools import partial, reduce
 from textwrap import dedent
 from typing import List
 
-from configupdater import ConfigUpdater
+from configupdater import ConfigUpdater, Option
 from pyscaffold.actions import Action, ActionParams, ScaffoldOpts, Structure
 from pyscaffold.extensions import Extension
 from pyscaffold.identification import dasherize
@@ -40,7 +40,9 @@ def add_long_desc(content: str) -> str:
     updater.read_string(content)
     metadata = updater["metadata"]
 
-    long_desc = metadata.get(dasherize(DESC_KEY)) or metadata.get(DESC_KEY)
+    dash_key = dasherize(DESC_KEY)
+    default = Option(DESC_KEY)
+    long_desc = metadata.get(dash_key) or metadata.setdefault(DESC_KEY, default)
     long_desc.key = DESC_KEY  # dash-separated keys are deprecated in setuptools
     long_desc.value = "file: README.md"
     long_desc_value = "text/markdown; charset=UTF-8; variant=GFM"

--- a/tox.ini
+++ b/tox.ini
@@ -71,3 +71,15 @@ deps = twine
 commands =
     python -m twine check dist/*
     python -m twine upload {posargs:--repository testpypi} dist/*
+
+
+[testenv:typecheck]
+description = Invoke mypy to typecheck the source code
+changedir = {toxinidir}
+passenv =
+    TERM
+    # ^ ensure colors
+deps =
+    mypy
+commands =
+    python -m mypy {posargs:src}


### PR DESCRIPTION
Now that `configupdater` is marked as typed, mypy is a bit more pedantic.
This PR tries to solve the type errors.

I also took the opportunity to add the `typecheck` task to `tox.ini` and sync `.cirrus.yml` with the one in the PyScaffold repository.