### PR TITLE
Fix links for GitHub docs

### DIFF
--- a/src/pyscaffoldext/markdown/templates/contributing.template
+++ b/src/pyscaffoldext/markdown/templates/contributing.template
@@ -339,7 +339,7 @@ on [PyPI], the following steps can be used to release a new version for
 [black]: https://pypi.org/project/black/
 [commonmark]: https://commonmark.org/
 [contribution-guide.org]: http://www.contribution-guide.org/
-[creating a pr]: https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
+[creating a pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request
 [descriptive commit message]: https://chris.beams.io/posts/git-commit
 [docstrings]: https://www.sphinx-doc.org/en/master/usage/extensions/napoleon.html
 [first-contributions tutorial]: https://github.com/firstcontributions/first-contributions


### PR DESCRIPTION
GitHub keeps changing the links to their documentation without setting up redirects...