### PR TITLE
Remove description section in README.md

### DIFF
--- a/src/pyscaffoldext/markdown/templates/readme.template
+++ b/src/pyscaffoldext/markdown/templates/readme.template
@@ -14,10 +14,7 @@
 
 # ${name}
 
-${description}
-
-
-## Description
+> ${description}
 
 A longer description of your project goes here...
 


### PR DESCRIPTION
This removes the `#Description` section in the same way we did it in README.rst.