### PR TITLE
Experiment with simplified `.coveragerc`

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,28 +1,10 @@
 # .coveragerc to control coverage.py
 [run]
 branch = True
-source = markdown
+source = pyscaffoldext.markdown
 # omit = bad_file.py
 
 [paths]
 source =
     src/
     */site-packages/
-
-[report]
-# Regexes for lines to exclude from consideration
-exclude_lines =
-    # Have to re-enable the standard pragma
-    pragma: no cover
-
-    # Don't complain about missing debug-only code:
-    def __repr__
-    if self\.debug
-
-    # Don't complain if tests don't hit defensive assertion code:
-    raise AssertionError
-    raise NotImplementedError
-
-    # Don't complain if non-runnable code isn't run:
-    if 0:
-    if __name__ == .__main__.:

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ pyscaffold.cli =
 # CAUTION: --cov flags may prohibit setting breakpoints while debugging.
 #          Comment those flags to avoid this py.test issue.
 addopts =
-    --cov pyscaffoldext.markdown --cov-report term-missing
+    --cov --cov-report term-missing
     --verbose
 norecursedirs =
     dist

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 [tox]
 minversion = 3.15
 envlist = default
+isolated_build = True
 
 
 [testenv]


### PR DESCRIPTION
This is an experiment to check if we can simplify PyScaffold's `.coveragerc` template.